### PR TITLE
Fix code scanning alert no. 13: Prototype-polluting assignment

### DIFF
--- a/venv/Lib/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
+++ b/venv/Lib/site-packages/urllib3/contrib/emscripten/emscripten_fetch_worker.js
@@ -12,10 +12,18 @@ const encoder = new TextEncoder();
 self.addEventListener("message", async function (event) {
   if (event.data.close) {
     let connectionID = event.data.close;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     delete connections[connectionID];
     return;
   } else if (event.data.getMore) {
     let connectionID = event.data.getMore;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     let { curOffset, value, reader, intBuffer, byteBuffer } =
       connections[connectionID];
     // if we still have some in buffer, then just send it back straight away
@@ -63,6 +71,10 @@ self.addEventListener("message", async function (event) {
   } else {
     // start fetch
     let connectionID = nextConnectionID;
+    if (connectionID === '__proto__' || connectionID === 'constructor' || connectionID === 'prototype') {
+      console.error("Invalid connectionID");
+      return;
+    }
     nextConnectionID += 1;
     const intBuffer = new Int32Array(event.data.buffer);
     const byteBuffer = new Uint8Array(event.data.buffer, 8);


### PR DESCRIPTION
Fixes [https://github.com/akaday/axiom/security/code-scanning/13](https://github.com/akaday/axiom/security/code-scanning/13)

To fix the problem, we need to ensure that the `connectionID` cannot be a special property name that could lead to prototype pollution. One way to achieve this is by checking if `connectionID` is one of the special property names (`__proto__`, `constructor`, `prototype`) and rejecting it if it is. This can be done by adding a validation step before using `connectionID` to access the `connections` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
